### PR TITLE
fix: prevent server crash when cost is missing in response

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -105,9 +105,8 @@ server.register(FastifyProxy, {
                 return;
             }
 
-            // eslint-disable-next-line prefer-destructuring
-            const cost = data.usage.cost;
-            if (!cost) {
+            const cost = data?.usage?.cost;
+            if (!cost || typeof cost !== 'number') {
                 request.log.error({ data }, 'Cannot read cost from response');
                 return;
             }


### PR DESCRIPTION
closing: https://github.com/apify/ai-team/issues/71

After parsing the response JSON, it was naive to read object properties. We added optional chaining and checked if cost is a number. I hope the actual code is bulletproof.